### PR TITLE
feat: TopTeamsSinclair video/chroma-key mode

### DIFF
--- a/owlcms/src/main/frontend/components/TopTeamsSinclair.js
+++ b/owlcms/src/main/frontend/components/TopTeamsSinclair.js
@@ -107,7 +107,7 @@ class TopTeamsSinclair extends LitElement {
   }
 
   activeClasses() {
-    return "wrapper ";
+    return "wrapper " + (this.video ? "video" : "");
   }
 
 }

--- a/owlcms/src/main/java/app/owlcms/displays/top/TopTeamsSinclair.java
+++ b/owlcms/src/main/java/app/owlcms/displays/top/TopTeamsSinclair.java
@@ -127,10 +127,6 @@ public class TopTeamsSinclair extends AbstractTop {
 	}
 
 	@Override
-	public void setVideo(boolean video) {
-	}
-
-	@Override
 	@Subscribe
 	public void slaveGroupDone(UIEvent.GroupDone e) {
 		uiLog(e);

--- a/owlcms/src/main/java/app/owlcms/nui/displays/VideoNavigationContent.java
+++ b/owlcms/src/main/java/app/owlcms/nui/displays/VideoNavigationContent.java
@@ -56,6 +56,7 @@ import app.owlcms.nui.displays.scoreboards.WarmupMultiRanksPage;
 import app.owlcms.nui.displays.scoreboards.WarmupNoLeadersPage;
 import app.owlcms.nui.displays.scoreboards.WarmupRankingOrderPage;
 import app.owlcms.nui.displays.scoreboards.WarmupScoreboardPage;
+import app.owlcms.nui.displays.top.TopTeamsSinclairPage;
 import app.owlcms.nui.home.HomeNavigationContent;
 import app.owlcms.nui.shared.BaseNavigationContent;
 import app.owlcms.nui.shared.NavigationPage;
@@ -185,12 +186,14 @@ public class VideoNavigationContent extends BaseNavigationContent
 		        Translator.translate("ScoreboardMultiRanksButton"), "video=true&currentAttempt=false");
 		Button scoreboardRankings = openInNewTabWithFopQueryParameters(WarmupRankingOrderPage.class,
 		        Translator.translate("Scoreboard.RankingOrderButton"), "video=true&currentAttempt=false");
+		Button topTeamsSinclair = openInNewTabWithFopQueryParameters(TopTeamsSinclairPage.class,
+		        Translator.translate("Scoreboard.TopTeamsScore", Translator.translate("Sinclair")), "video=true");
 
 		VerticalLayout intro1 = new VerticalLayout();
 		// addP(intro1, Translator.translate("darkModeSelect"));
 		FlexibleGridLayout grid1 = HomeNavigationContent.navigationGrid(scoreboard, scoreboardWLeaders,
 		        scoreboardRankings,
-		        scoreboardMultiRanks);
+		        scoreboardMultiRanks, topTeamsSinclair);
 		doGroup(Translator.translate("Scoreboards"), intro1, grid1, this);
 	}
 


### PR DESCRIPTION
## Summary

- Removes the empty `setVideo()` stub in `TopTeamsSinclair.java` that was silently blocking the inherited `computeStylesDir()` — without it, `stylesDir` never switched to `transparent/` and the element never received `video=true`, so green screen CSS was never loaded
- Wires the `video` property into `activeClasses()` in `TopTeamsSinclair.js` (adds `.video` class to the wrapper) so CSS can target video-specific overrides
- Adds a **TopTeamsSinclair** button with `video=true` to `VideoNavigationContent` (the `/video=true` overlay page) under the Scoreboards group

## Test plan

- [ ] Open `/video=true?fop=A` — verify "Team Sinclair" button appears in Scoreboards section
- [ ] Click button — verify display opens at `/displays/topteamsinclair?fop=A&video=true` with chroma-key green (`#00ff00`) background
- [ ] Open without `video=true` — verify dark blue background unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)